### PR TITLE
Fixed typographical error, changed accomadate to accommodate in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ COMMANDS
 
 ASSIGNMENTS:
 ============
-Chuong Ngo - working on adding logging to the script.  The "logging" will output messages to the screen, depending on the log level used.  The appropriate commands will also be added.  Cleaning up the back end to accomadate future enhancments and prepare it for release at v1.0.
+Chuong Ngo - working on adding logging to the script.  The "logging" will output messages to the screen, depending on the log level used.  The appropriate commands will also be added.  Cleaning up the back end to accommodate future enhancments and prepare it for release at v1.0.
 
 braind - reworking the UI.
 


### PR DESCRIPTION
cngo-github, I've corrected a typographical error in the documentation of the [xchat-translator](https://github.com/cngo-github/xchat-translator) project. You should be able to merge this pull request automatically. However, if this was intentional or you enjoy living in linguistic squalor please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.